### PR TITLE
Fix ambiguous argument edge case error from git

### DIFF
--- a/src/branches/utils/git_utils.py
+++ b/src/branches/utils/git_utils.py
@@ -92,7 +92,8 @@ class GitUtils:
   def parent_shas_of_ref(self, ref: str, n: int = 1) -> list[list[str]]:
     ret = []
 
-    for line in self._cmd.execute(['git', 'rev-list', '--parents', f'-n{n}', ref]).split('\n'):
+    command = ['git', 'rev-list', '--parents', f'-n{n}', ref, '--']
+    for line in self._cmd.execute(command).split('\n'):
       ret.append(re.split(r'\s+', line.strip()))
 
     return ret


### PR DESCRIPTION
Issue occurs when a branch has the same  name as a file, and user is on that branch. In that case, `git` crashes during the `git rev-list --parents -n1 branchname` step with `fatal: ambiguous argument 'bashin': both revision and filename`. The fix is to append `--` to separate ref vs filename.
