### PR TITLE
Fix undesired behavior pulling `main`

### DIFF
--- a/src/branches/cli.py
+++ b/src/branches/cli.py
@@ -325,9 +325,6 @@ def table_row(
       if remote_commit is None:
         remote_commit = git_utils.fetch_sigle_sha(remote_sha)
 
-      if branch == ret["main_branch"]:
-        ret["unsynced_main"] = True
-
   try:
     pr = None
     if "GITHUB_TOKEN" in os.environ:
@@ -385,6 +382,8 @@ def table_row(
       row_dict["relationship"] = "<"
     elif git_utils.is_ancestor(local_commit, remote_commit):
       row_dict["relationship"] = ">"
+      if branch == ret["main_branch"]:
+        ret["unsynced_main"] = True
     else:
       row_dict["relationship"] = "[yellow]Y[/yellow]"
   else:

--- a/tests/branches/test_cli.py
+++ b/tests/branches/test_cli.py
@@ -617,7 +617,6 @@ def test_cli_misc():
   )
 
   # When the local `main` is ahead and the remote sha is an ancestor
-  # This shows an undesired behavior of this tool - we shouldn't try to pull in this scenario
   run_test(
     " && ".join(
       [
@@ -633,9 +632,6 @@ def test_cli_misc():
       r" ──────────────────────────────────────── ",
       r"  \w{5} < \w{5}    0  0 0  main           ",
       r"                                          ",
-      r"git checkout main && git pull && \\",
-      r"git checkout main",
-      r"",
     ],
   )
 
@@ -656,7 +652,6 @@ def test_cli_misc():
   )
 
   # When the remote `main` and local `main` deviated
-  # This shows an undesired behavior of this tool - we shouldn't try to pull in this scenario
   run_test(
     " && ".join(
       [
@@ -671,9 +666,6 @@ def test_cli_misc():
       r" ──────────────────────────────────────── ",
       r"  \w{5} Y \w{5}    0  0 0  main           ",
       r"                                          ",
-      r"git checkout main && git pull && \\",
-      r"git checkout main",
-      r"",
     ],
   )
 


### PR DESCRIPTION
Closes #22 

Fixes the undesired behavior of suggesting to pull the latest changes from `main` when `main` is either behind or deviated.